### PR TITLE
Fixed detection of all-parents

### DIFF
--- a/denote-sequence.el
+++ b/denote-sequence.el
@@ -711,7 +711,7 @@ returned by `denote-sequence-get-all-files'."
     (pcase type
       ('all-parents (let ((parents nil)
                           (butlast (butlast components)))
-                      (while (>= (length butlast) 1)
+                      (while (> (length butlast) 1)
                         (when-let* ((prefix (denote-sequence-join butlast scheme))
                                     (parent (seq-find
                                              (lambda (file)


### PR DESCRIPTION
The while loop was stuck in infinity when finding a note's ancestors (all-parents).