### PR TITLE
fix: denote-sequence-dired throw an error

### DIFF
--- a/denote-sequence.el
+++ b/denote-sequence.el
@@ -1109,7 +1109,7 @@ For a more specialised case, see `denote-sequence-find-relatives-dired'."
   (interactive (denote-sequence--get-interactive-for-prefix-and-depth))
   (pcase-let* ((relative-p (denote-has-single-denote-directory-p))
                (files-fn `(lambda ()
-                            (let* ((files (if (and prefix (not (string-blank-p prefix)))
+                            (let* ((files (if (and ,prefix (not (string-blank-p ,prefix)))
                                               (denote-sequence-get-all-files-with-prefix ,prefix)
                                             (denote-sequence-get-all-files)))
                                    (files-with-depth (if ,depth


### PR DESCRIPTION
error message: "Symbol’s value as variable is void: prefix"